### PR TITLE
avances completos

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,37 @@
-# React + Vite
+# Weather App
 
-This template provides a minimal setup to get React working in Vite with HMR and some ESLint rules.
+Aplicación de pronóstico del clima construida con React y Vite siguiendo el challenge de [DevChallenges](https://devchallenges.io/challenge/weather-app). Permite buscar el clima actual y el pronóstico de los próximos días para cualquier ciudad, alternar entre unidades Celsius/Fahrenheit y elegir modo claro/oscuro.
 
-Currently, two official plugins are available:
+## Requisitos previos
 
-- [@vitejs/plugin-react](https://github.com/vitejs/vite-plugin-react/blob/main/packages/plugin-react) uses [Babel](https://babeljs.io/) for Fast Refresh
-- [@vitejs/plugin-react-swc](https://github.com/vitejs/vite-plugin-react/blob/main/packages/plugin-react-swc) uses [SWC](https://swc.rs/) for Fast Refresh
+1. Crear una cuenta gratuita en [OpenWeather](https://openweathermap.org/price) y obtener una API Key.
+2. Crear un archivo `.env.local` en la raíz del proyecto con la siguiente variable:
 
-## Expanding the ESLint configuration
+```bash
+VITE_OPENWEATHER_API_KEY=tu_api_key_aquí
+```
 
-If you are developing a production application, we recommend using TypeScript with type-aware lint rules enabled. Check out the [TS template](https://github.com/vitejs/vite/tree/main/packages/create-vite/template-react-ts) for information on how to integrate TypeScript and [`typescript-eslint`](https://typescript-eslint.io) in your project.
+La API Key no se versiona. Sin ella la aplicación mostrará un error al intentar obtener el clima.
+
+## Scripts disponibles
+
+- `npm install`: instala las dependencias.
+- `npm run dev`: inicia el servidor de desarrollo.
+- `npm run build`: genera la versión optimizada para producción.
+- `npm run preview`: sirve la build generada.
+- `npm run lint`: ejecuta ESLint sobre el proyecto.
+
+## Funcionalidades principales
+
+- Búsqueda de clima actual por ciudad o por geolocalización del navegador.
+- Pronóstico resumido de los próximos 5 días.
+- Indicadores destacados (sensación térmica, viento, humedad, visibilidad, presión, amanecer/atardecer y nubosidad).
+- Cambio global de unidades (°C ↔ °F) mediante Context API.
+- Tema claro/oscuro con persistencia en `localStorage`.
+
+## Tecnologías
+
+- React 19 + Vite
+- Context API para manejo de estado global (configuración y datos del clima)
+- Fetch API para consultar el servicio de OpenWeather
+- CSS puro con variables y soporte para modo oscuro

--- a/src/App.css
+++ b/src/App.css
@@ -1,42 +1,421 @@
-#root {
-  max-width: 1280px;
+.app-layout {
+  min-height: 100vh;
+  padding: 48px;
+  display: grid;
+  grid-template-columns: minmax(280px, 360px) 1fr;
+  gap: 48px;
+  max-width: 1200px;
   margin: 0 auto;
-  padding: 2rem;
+}
+
+.sidebar {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+  background: var(--color-sidebar);
+  border-radius: var(--radius-large);
+  padding: 32px;
+  box-shadow: var(--shadow-large);
+  overflow: hidden;
+}
+
+.sidebar::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(circle at top, rgba(99, 102, 241, 0.25), transparent 60%),
+    radial-gradient(circle at bottom, rgba(167, 139, 250, 0.28), transparent 55%);
+  pointer-events: none;
+  z-index: 0;
+}
+
+.sidebar > * {
+  position: relative;
+  z-index: 1;
+}
+
+.sidebar__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.app-title {
+  margin: 0;
+  font-size: 1.8rem;
+  font-weight: 700;
+}
+
+.icon-button {
+  width: 44px;
+  height: 44px;
+  border-radius: 50%;
+  background: var(--color-surface);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 1.3rem;
+  box-shadow: var(--shadow-soft);
+  transition: transform var(--transition-base), box-shadow var(--transition-base);
+}
+
+.icon-button:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 16px 30px rgba(79, 70, 229, 0.25);
+}
+
+.search-form {
+  display: flex;
+  gap: 12px;
+  background: var(--color-surface);
+  padding: 10px 12px;
+  border-radius: var(--radius-medium);
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.2);
+}
+
+.search-form input {
+  flex: 1;
+  padding: 12px 16px;
+  border-radius: var(--radius-small);
+  background: rgba(255, 255, 255, 0.5);
+  color: var(--color-text-primary);
+}
+
+[data-theme='dark'] .search-form input {
+  background: rgba(15, 23, 42, 0.3);
+  color: var(--color-text-primary);
+}
+
+.search-button {
+  padding: 12px 20px;
+  border-radius: var(--radius-small);
+  background: var(--color-accent);
+  color: #fff;
+  font-weight: 600;
+  transition: background var(--transition-base), transform var(--transition-base);
+  box-shadow: 0 12px 24px rgba(99, 102, 241, 0.3);
+}
+
+.search-button:hover {
+  background: var(--color-accent-strong);
+  transform: translateY(-1px);
+}
+
+.secondary-button {
+  width: 100%;
+  padding: 12px 20px;
+  border-radius: var(--radius-medium);
+  background: var(--color-surface);
+  color: var(--color-text-primary);
+  font-weight: 600;
+  box-shadow: var(--shadow-soft);
+  transition: transform var(--transition-base), box-shadow var(--transition-base);
+}
+
+.secondary-button:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 15px 30px rgba(79, 70, 229, 0.2);
+}
+
+.hint {
+  margin: 0;
+  font-size: 0.9rem;
+  color: var(--color-text-secondary);
+}
+
+.hint--error {
+  color: var(--color-error);
+}
+
+.weather-summary {
+  margin-top: auto;
   text-align: center;
+  background: rgba(255, 255, 255, 0.78);
+  border-radius: var(--radius-large);
+  padding: 36px 20px;
+  box-shadow: var(--shadow-soft);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 12px;
 }
 
-.logo {
-  height: 6em;
-  padding: 1.5em;
-  will-change: filter;
-  transition: filter 300ms;
-}
-.logo:hover {
-  filter: drop-shadow(0 0 2em #646cffaa);
-}
-.logo.react:hover {
-  filter: drop-shadow(0 0 2em #61dafbaa);
+[data-theme='dark'] .weather-summary {
+  background: rgba(17, 34, 64, 0.7);
 }
 
-@keyframes logo-spin {
+.weather-summary.empty {
+  padding: 24px;
+  font-size: 1rem;
+  color: var(--color-text-secondary);
+}
+
+.weather-summary__icon {
+  width: 160px;
+  height: 160px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.weather-summary__icon img {
+  width: 100%;
+}
+
+.weather-summary__icon--placeholder {
+  width: 120px;
+  height: 120px;
+  border-radius: 50%;
+  background: var(--color-surface);
+  box-shadow: inset 0 0 0 1px rgba(148, 163, 184, 0.25);
+}
+
+.weather-summary__temperature {
+  font-size: 4rem;
+  line-height: 1;
+  margin: 12px 0 0;
+  font-weight: 600;
+}
+
+.weather-summary__description {
+  margin: 0;
+  font-size: 1.1rem;
+  color: var(--color-text-secondary);
+  text-transform: capitalize;
+}
+
+.weather-summary__date,
+.weather-summary__location {
+  margin: 0;
+  color: var(--color-text-secondary);
+}
+
+.weather-summary__range {
+  margin: 12px 0 0;
+  display: flex;
+  justify-content: center;
+  gap: 16px;
+  font-weight: 600;
+  color: var(--color-text-secondary);
+}
+
+.weather-summary__range span:first-child {
+  color: var(--color-text-primary);
+}
+
+.main-content {
+  position: relative;
+  background: rgba(255, 255, 255, 0.8);
+  backdrop-filter: blur(18px);
+  border-radius: var(--radius-large);
+  padding: 36px;
+  display: flex;
+  flex-direction: column;
+  gap: 32px;
+  box-shadow: var(--shadow-large);
+}
+
+[data-theme='dark'] .main-content {
+  background: rgba(17, 34, 64, 0.7);
+}
+
+.main-content__toolbar {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 16px;
+}
+
+.last-update {
+  margin: 0;
+  color: var(--color-text-secondary);
+  font-size: 0.95rem;
+}
+
+.units-toggle {
+  display: inline-flex;
+  padding: 6px;
+  gap: 6px;
+  border-radius: 999px;
+  background: var(--color-surface);
+  box-shadow: var(--shadow-soft);
+}
+
+.units-toggle button {
+  padding: 6px 16px;
+  border-radius: 999px;
+  font-weight: 600;
+  color: var(--color-text-secondary);
+  transition: background var(--transition-base), color var(--transition-base);
+}
+
+.units-toggle button.active {
+  background: var(--color-accent);
+  color: #fff;
+  box-shadow: 0 12px 30px rgba(99, 102, 241, 0.35);
+}
+
+.forecast h2,
+.weather-highlights h2 {
+  margin: 0 0 16px;
+  font-size: 1.3rem;
+}
+
+.forecast__grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+  gap: 16px;
+}
+
+.forecast-card {
+  padding: 20px 16px;
+  border-radius: var(--radius-medium);
+  background: var(--color-card);
+  text-align: center;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  box-shadow: var(--shadow-soft);
+}
+
+.forecast-card__icon {
+  display: flex;
+  justify-content: center;
+}
+
+.forecast-card__icon--placeholder {
+  width: 64px;
+  height: 64px;
+  border-radius: 20px;
+  background: var(--color-surface);
+  box-shadow: inset 0 0 0 1px rgba(148, 163, 184, 0.25);
+}
+
+.forecast-card__date {
+  margin: 0;
+  font-weight: 600;
+}
+
+.forecast-card__description {
+  margin: 0;
+  color: var(--color-text-secondary);
+  text-transform: capitalize;
+}
+
+.forecast-card__temperatures {
+  display: flex;
+  justify-content: center;
+  gap: 12px;
+  font-weight: 600;
+}
+
+.forecast-card__temperatures span:last-child {
+  color: var(--color-text-secondary);
+}
+
+.weather-highlights__grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 18px;
+}
+
+.highlight-card {
+  background: var(--color-card);
+  padding: 22px 20px;
+  border-radius: var(--radius-medium);
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  box-shadow: var(--shadow-soft);
+}
+
+.highlight-card__label {
+  margin: 0;
+  color: var(--color-text-secondary);
+}
+
+.highlight-card__value {
+  margin: 0;
+  font-size: 1.4rem;
+  font-weight: 600;
+}
+
+.highlight-card__detail {
+  margin: 0;
+  color: var(--color-text-secondary);
+  font-size: 0.95rem;
+}
+
+.loader {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+}
+
+.loader span {
+  width: 10px;
+  height: 10px;
+  border-radius: 999px;
+  background: var(--color-accent);
+  animation: loader 0.9s infinite alternate;
+}
+
+.loader span:nth-child(2) {
+  animation-delay: 0.15s;
+}
+
+.loader span:nth-child(3) {
+  animation-delay: 0.3s;
+}
+
+@keyframes loader {
   from {
-    transform: rotate(0deg);
+    transform: scale(0.8);
+    opacity: 0.6;
   }
   to {
-    transform: rotate(360deg);
+    transform: scale(1.4);
+    opacity: 1;
   }
 }
 
-@media (prefers-reduced-motion: no-preference) {
-  a:nth-of-type(2) .logo {
-    animation: logo-spin infinite 20s linear;
+.loading-overlay {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(15, 23, 42, 0.08);
+  border-radius: inherit;
+  backdrop-filter: blur(6px);
+  pointer-events: none;
+}
+
+[data-theme='dark'] .loading-overlay {
+  background: rgba(15, 23, 42, 0.3);
+}
+
+@media (max-width: 1080px) {
+  .app-layout {
+    grid-template-columns: 1fr;
+    gap: 32px;
+    padding: 32px;
   }
 }
 
-.card {
-  padding: 2em;
-}
+@media (max-width: 640px) {
+  .app-layout {
+    padding: 24px 16px;
+  }
 
-.read-the-docs {
-  color: #888;
+  .sidebar,
+  .main-content {
+    padding: 24px;
+  }
+
+  .weather-summary__temperature {
+    font-size: 3.2rem;
+  }
 }

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,34 +1,94 @@
 import { useState } from 'react'
-import reactLogo from './assets/react.svg'
-import viteLogo from '/vite.svg'
+import SearchForm from './components/SearchForm.jsx'
+import LocationButton from './components/LocationButton.jsx'
+import ThemeToggle from './components/ThemeToggle.jsx'
+import UnitsToggle from './components/UnitsToggle.jsx'
+import WeatherSummary from './components/WeatherSummary.jsx'
+import ForecastList from './components/ForecastList.jsx'
+import WeatherHighlights from './components/WeatherHighlights.jsx'
+import Loader from './components/Loader.jsx'
+import { useWeather } from './context/WeatherContext.jsx'
+import { capitalize, DEFAULT_LOCALE } from './utils/formatters.js'
 import './App.css'
 
 function App() {
-  const [count, setCount] = useState(0)
+  const { weather, status, error, searchByCity, searchByCoords } = useWeather()
+  const [locationError, setLocationError] = useState(null)
+  const [isLocating, setIsLocating] = useState(false)
+
+  const isLoading = status === 'loading'
+
+  const handleSearch = (query) => {
+    setLocationError(null)
+    searchByCity(query)
+  }
+
+  const handleUseLocation = () => {
+    if (typeof navigator === 'undefined' || !navigator.geolocation) {
+      setLocationError('Tu navegador no permite obtener la ubicación automáticamente.')
+      return
+    }
+
+    setLocationError(null)
+    setIsLocating(true)
+
+    navigator.geolocation.getCurrentPosition(
+      (position) => {
+        setIsLocating(false)
+        searchByCoords({
+          lat: position.coords.latitude,
+          lon: position.coords.longitude,
+        })
+      },
+      (geoError) => {
+        console.warn('Error al obtener la ubicación', geoError)
+        setIsLocating(false)
+        setLocationError('No pudimos acceder a tu ubicación. Revisá los permisos del navegador.')
+      },
+      { timeout: 10000 },
+    )
+  }
+
+  let lastUpdateLabel = null
+
+  if (weather) {
+    try {
+      lastUpdateLabel = new Intl.DateTimeFormat(DEFAULT_LOCALE, {
+        hour: '2-digit',
+        minute: '2-digit',
+      }).format(new Date(weather.updatedAt))
+    } catch {
+      lastUpdateLabel = new Date(weather.updatedAt).toLocaleTimeString()
+    }
+  }
 
   return (
-    <>
-      <div>
-        <a href="https://vite.dev" target="_blank">
-          <img src={viteLogo} className="logo" alt="Vite logo" />
-        </a>
-        <a href="https://react.dev" target="_blank">
-          <img src={reactLogo} className="logo react" alt="React logo" />
-        </a>
-      </div>
-      <h1>Vite + React</h1>
-      <div className="card">
-        <button onClick={() => setCount((count) => count + 1)}>
-          count is {count}
-        </button>
-        <p>
-          Edit <code>src/App.jsx</code> and save to test HMR
-        </p>
-      </div>
-      <p className="read-the-docs">
-        Click on the Vite and React logos to learn more
-      </p>
-    </>
+    <div className="app-layout">
+      <aside className="sidebar">
+        <header className="sidebar__header">
+          <h1 className="app-title">Pronóstico</h1>
+          <ThemeToggle />
+        </header>
+        <SearchForm onSearch={handleSearch} isLoading={isLoading} />
+        <LocationButton onClick={handleUseLocation} isLoading={isLocating || isLoading} />
+        {locationError ? <p className="hint hint--error">{locationError}</p> : null}
+        {error ? <p className="hint hint--error">{capitalize(error.message)}</p> : null}
+        {isLoading && !weather ? <Loader /> : <WeatherSummary weather={weather} />}
+      </aside>
+      <main className="main-content">
+        <div className="main-content__toolbar">
+          <UnitsToggle />
+          {lastUpdateLabel ? <p className="last-update">Actualizado {lastUpdateLabel}</p> : null}
+        </div>
+        {isLoading && weather ? (
+          <div className="loading-overlay">
+            <Loader />
+          </div>
+        ) : null}
+        <ForecastList weather={weather} />
+        <WeatherHighlights weather={weather} />
+      </main>
+    </div>
   )
 }
 

--- a/src/components/ForecastList.jsx
+++ b/src/components/ForecastList.jsx
@@ -1,0 +1,34 @@
+import { capitalize, formatShortDate, formatTemperature, getWeatherIconUrl } from '../utils/formatters.js'
+
+export default function ForecastList({ weather }) {
+  if (!weather || !weather.forecast?.length) return null
+
+  const { forecast, units, location } = weather
+
+  return (
+    <section className="forecast">
+      <h2>Próximos días</h2>
+      <div className="forecast__grid">
+        {forecast.map((day) => (
+          <article key={day.dateKey} className="forecast-card">
+            <p className="forecast-card__date">
+              {formatShortDate(day.timestamp, location.timezoneOffset)}
+            </p>
+            <div className="forecast-card__icon">
+              {day.icon ? (
+                <img src={getWeatherIconUrl(day.icon, 2)} alt={day.description ?? ''} />
+              ) : (
+                <div className="forecast-card__icon--placeholder" aria-hidden="true" />
+              )}
+            </div>
+            <p className="forecast-card__description">{capitalize(day.description)}</p>
+            <div className="forecast-card__temperatures">
+              <span>{formatTemperature(day.maxTemp, units)}</span>
+              <span>{formatTemperature(day.minTemp, units)}</span>
+            </div>
+          </article>
+        ))}
+      </div>
+    </section>
+  )
+}

--- a/src/components/Loader.jsx
+++ b/src/components/Loader.jsx
@@ -1,0 +1,9 @@
+export default function Loader() {
+  return (
+    <div className="loader" aria-label="Cargando">
+      <span />
+      <span />
+      <span />
+    </div>
+  )
+}

--- a/src/components/LocationButton.jsx
+++ b/src/components/LocationButton.jsx
@@ -1,0 +1,12 @@
+export default function LocationButton({ onClick, isLoading }) {
+  return (
+    <button
+      type="button"
+      className="secondary-button"
+      onClick={onClick}
+      disabled={isLoading}
+    >
+      {isLoading ? 'Obteniendo ubicación…' : 'Usar mi ubicación'}
+    </button>
+  )
+}

--- a/src/components/SearchForm.jsx
+++ b/src/components/SearchForm.jsx
@@ -1,0 +1,29 @@
+import { useState } from 'react'
+
+export default function SearchForm({ onSearch, isLoading }) {
+  const [value, setValue] = useState('')
+
+  const handleSubmit = (event) => {
+    event.preventDefault()
+    const trimmed = value.trim()
+    if (!trimmed) return
+    onSearch?.(trimmed)
+  }
+
+  return (
+    <form className="search-form" onSubmit={handleSubmit}>
+      <input
+        type="text"
+        name="city"
+        autoComplete="off"
+        placeholder="Buscar ciudad"
+        value={value}
+        onChange={(event) => setValue(event.target.value)}
+        aria-label="Buscar ciudad"
+      />
+      <button type="submit" className="search-button" disabled={isLoading}>
+        {isLoading ? 'Buscando…' : 'Buscar'}
+      </button>
+    </form>
+  )
+}

--- a/src/components/ThemeToggle.jsx
+++ b/src/components/ThemeToggle.jsx
@@ -1,0 +1,16 @@
+import { useSettings } from '../context/SettingsContext.jsx'
+
+export default function ThemeToggle() {
+  const { theme, toggleTheme } = useSettings()
+
+  return (
+    <button
+      type="button"
+      className="icon-button"
+      onClick={toggleTheme}
+      aria-label={theme === 'dark' ? 'Cambiar a modo claro' : 'Cambiar a modo oscuro'}
+    >
+      {theme === 'dark' ? '🌙' : '☀️'}
+    </button>
+  )
+}

--- a/src/components/UnitsToggle.jsx
+++ b/src/components/UnitsToggle.jsx
@@ -1,0 +1,24 @@
+import { useSettings } from '../context/SettingsContext.jsx'
+
+export default function UnitsToggle() {
+  const { units, setUnits } = useSettings()
+
+  return (
+    <div className="units-toggle" role="group" aria-label="Cambiar unidad de temperatura">
+      <button
+        type="button"
+        className={units === 'metric' ? 'active' : ''}
+        onClick={() => setUnits('metric')}
+      >
+        °C
+      </button>
+      <button
+        type="button"
+        className={units === 'imperial' ? 'active' : ''}
+        onClick={() => setUnits('imperial')}
+      >
+        °F
+      </button>
+    </div>
+  )
+}

--- a/src/components/WeatherHighlights.jsx
+++ b/src/components/WeatherHighlights.jsx
@@ -1,0 +1,73 @@
+import {
+  formatDistance,
+  formatPercentage,
+  formatPressure,
+  formatSpeed,
+  formatTemperature,
+  formatTime,
+} from '../utils/formatters.js'
+
+export default function WeatherHighlights({ weather }) {
+  if (!weather) return null
+
+  const { current, location, units } = weather
+
+  const items = [
+    {
+      id: 'feels-like',
+      label: 'Sensación térmica',
+      value: formatTemperature(current.feelsLike, units),
+    },
+    {
+      id: 'wind',
+      label: 'Viento',
+      value: formatSpeed(current.windSpeed, units),
+      detail: current.windDirection ? `Dirección ${current.windDirection}` : null,
+    },
+    {
+      id: 'humidity',
+      label: 'Humedad',
+      value: formatPercentage(current.humidity),
+    },
+    {
+      id: 'visibility',
+      label: 'Visibilidad',
+      value: formatDistance(current.visibility, units),
+    },
+    {
+      id: 'pressure',
+      label: 'Presión',
+      value: formatPressure(current.pressure),
+    },
+    {
+      id: 'sunrise',
+      label: 'Amanecer',
+      value: formatTime(current.sunrise, location.timezoneOffset),
+    },
+    {
+      id: 'sunset',
+      label: 'Atardecer',
+      value: formatTime(current.sunset, location.timezoneOffset),
+    },
+    {
+      id: 'clouds',
+      label: 'Nubosidad',
+      value: formatPercentage(current.clouds),
+    },
+  ]
+
+  return (
+    <section className="weather-highlights">
+      <h2>Condiciones actuales</h2>
+      <div className="weather-highlights__grid">
+        {items.map((item) => (
+          <article key={item.id} className="highlight-card">
+            <p className="highlight-card__label">{item.label}</p>
+            <p className="highlight-card__value">{item.value}</p>
+            {item.detail ? <p className="highlight-card__detail">{item.detail}</p> : null}
+          </article>
+        ))}
+      </div>
+    </section>
+  )
+}

--- a/src/components/WeatherSummary.jsx
+++ b/src/components/WeatherSummary.jsx
@@ -1,0 +1,37 @@
+import { capitalize, formatDate, formatTemperature, getWeatherIconUrl } from '../utils/formatters.js'
+
+export default function WeatherSummary({ weather }) {
+  if (!weather) {
+    return (
+      <section className="weather-summary empty">
+        <p>Buscá una ciudad para ver el clima actual.</p>
+      </section>
+    )
+  }
+
+  const { current, location, units } = weather
+  const iconUrl = getWeatherIconUrl(current.icon)
+
+  return (
+    <section className="weather-summary">
+      <div className="weather-summary__icon">
+        {iconUrl ? (
+          <img src={iconUrl} alt={current.description ?? ''} />
+        ) : (
+          <div className="weather-summary__icon--placeholder" aria-hidden="true" />
+        )}
+      </div>
+      <p className="weather-summary__temperature">{formatTemperature(current.temperature, units)}</p>
+      <p className="weather-summary__description">{capitalize(current.description)}</p>
+      <p className="weather-summary__date">{formatDate(current.timestamp, location.timezoneOffset)}</p>
+      <p className="weather-summary__location">
+        {location.name}
+        {location.country ? `, ${location.country}` : ''}
+      </p>
+      <p className="weather-summary__range">
+        <span>Máx {formatTemperature(current.tempMax, units)}</span>
+        <span>Mín {formatTemperature(current.tempMin, units)}</span>
+      </p>
+    </section>
+  )
+}

--- a/src/context/SettingsContext.jsx
+++ b/src/context/SettingsContext.jsx
@@ -1,0 +1,94 @@
+import { createContext, useContext, useEffect, useMemo, useState } from 'react'
+
+const SettingsContext = createContext(null)
+
+const STORAGE_KEY = 'weather-app-settings'
+
+function getInitialSettings() {
+  if (typeof window === 'undefined') {
+    return { theme: 'light', units: 'metric' }
+  }
+
+  try {
+    const stored = window.localStorage.getItem(STORAGE_KEY)
+    if (stored) {
+      const parsed = JSON.parse(stored)
+      if (parsed && typeof parsed === 'object') {
+        return {
+          theme: parsed.theme === 'dark' ? 'dark' : 'light',
+          units: parsed.units === 'imperial' ? 'imperial' : 'metric',
+        }
+      }
+    }
+  } catch (error) {
+    console.warn('Unable to read settings from localStorage', error)
+  }
+
+  const prefersDark = window.matchMedia?.('(prefers-color-scheme: dark)')?.matches
+
+  return {
+    theme: prefersDark ? 'dark' : 'light',
+    units: 'metric',
+  }
+}
+
+export function SettingsProvider({ children }) {
+  const [settings, setSettings] = useState(() => getInitialSettings())
+
+  useEffect(() => {
+    if (typeof document === 'undefined') return
+
+    document.documentElement.dataset.theme = settings.theme
+  }, [settings.theme])
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return
+
+    try {
+      window.localStorage.setItem(STORAGE_KEY, JSON.stringify(settings))
+    } catch (error) {
+      console.warn('Unable to persist settings on localStorage', error)
+    }
+  }, [settings])
+
+  const value = useMemo(
+    () => ({
+      theme: settings.theme,
+      units: settings.units,
+      setTheme: (theme) =>
+        setSettings((prev) => ({
+          ...prev,
+          theme: theme === 'dark' ? 'dark' : 'light',
+        })),
+      toggleTheme: () =>
+        setSettings((prev) => ({
+          ...prev,
+          theme: prev.theme === 'dark' ? 'light' : 'dark',
+        })),
+      setUnits: (units) =>
+        setSettings((prev) => ({
+          ...prev,
+          units: units === 'imperial' ? 'imperial' : 'metric',
+        })),
+      toggleUnits: () =>
+        setSettings((prev) => ({
+          ...prev,
+          units: prev.units === 'metric' ? 'imperial' : 'metric',
+        })),
+    }),
+    [settings.theme, settings.units],
+  )
+
+  return <SettingsContext.Provider value={value}>{children}</SettingsContext.Provider>
+}
+
+// eslint-disable-next-line react-refresh/only-export-components
+export function useSettings() {
+  const context = useContext(SettingsContext)
+
+  if (!context) {
+    throw new Error('useSettings must be used within a SettingsProvider')
+  }
+
+  return context
+}

--- a/src/context/WeatherContext.jsx
+++ b/src/context/WeatherContext.jsx
@@ -1,0 +1,119 @@
+import { createContext, useCallback, useContext, useEffect, useMemo, useRef, useState } from 'react'
+import { getWeatherData } from '../services/weatherService.js'
+import { useSettings } from './SettingsContext.jsx'
+
+const WeatherContext = createContext(null)
+
+export function WeatherProvider({ children }) {
+  const { units } = useSettings()
+  const [weather, setWeather] = useState(null)
+  const [status, setStatus] = useState('idle')
+  const [error, setError] = useState(null)
+  const lastRequestRef = useRef(null)
+  const abortControllerRef = useRef(null)
+
+  const performFetch = useCallback(
+    async (request, options = {}) => {
+      if (!request) return
+
+      abortControllerRef.current?.abort()
+      const controller = new AbortController()
+      abortControllerRef.current = controller
+
+      setStatus('loading')
+      setError(null)
+
+      try {
+        const data = await getWeatherData({
+          ...request,
+          units,
+          signal: controller.signal,
+        })
+
+        if (options.persistRequest !== false) {
+          lastRequestRef.current = request
+        }
+
+        setWeather(data)
+        setStatus('success')
+      } catch (fetchError) {
+        if (fetchError.name === 'AbortError') {
+          return
+        }
+
+        let normalizedError = fetchError
+
+        if (fetchError?.status === 404) {
+          normalizedError = new Error('No encontramos esa ciudad. Probá con otra búsqueda.')
+          normalizedError.status = fetchError.status
+        } else if (!fetchError?.message) {
+          normalizedError = new Error('Ocurrió un error al obtener el clima. Intentá nuevamente más tarde.')
+          normalizedError.status = fetchError?.status
+        }
+
+        setError(normalizedError)
+        setStatus('error')
+      }
+    },
+    [units],
+  )
+
+  const searchByCity = useCallback(
+    (city) => {
+      const trimmedCity = city?.trim()
+      if (!trimmedCity) return
+
+      performFetch({ type: 'city', value: trimmedCity })
+    },
+    [performFetch],
+  )
+
+  const searchByCoords = useCallback(
+    (coords) => {
+      if (!coords || typeof coords.lat !== 'number' || typeof coords.lon !== 'number') {
+        return
+      }
+
+      performFetch({ type: 'coords', value: { lat: coords.lat, lon: coords.lon } })
+    },
+    [performFetch],
+  )
+
+  useEffect(() => {
+    if (!lastRequestRef.current) return
+
+    performFetch(lastRequestRef.current, { persistRequest: false })
+  }, [units, performFetch])
+
+  useEffect(() => {
+    searchByCity('Buenos Aires')
+
+    return () => {
+      abortControllerRef.current?.abort()
+    }
+  }, [searchByCity])
+
+  const value = useMemo(
+    () => ({
+      weather,
+      status,
+      error,
+      searchByCity,
+      searchByCoords,
+    }),
+    [error, searchByCity, searchByCoords, status, weather],
+  )
+
+  return <WeatherContext.Provider value={value}>{children}</WeatherContext.Provider>
+}
+
+// eslint-disable-next-line react-refresh/only-export-components
+export function useWeather() {
+  const context = useContext(WeatherContext)
+
+  if (!context) {
+    throw new Error('useWeather must be used within a WeatherProvider')
+  }
+
+  return context
+}

--- a/src/index.css
+++ b/src/index.css
@@ -1,68 +1,85 @@
 :root {
-  font-family: system-ui, Avenir, Helvetica, Arial, sans-serif;
+  color-scheme: light;
+  font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
   line-height: 1.5;
   font-weight: 400;
 
-  color-scheme: light dark;
-  color: rgba(255, 255, 255, 0.87);
-  background-color: #242424;
-
-  font-synthesis: none;
-  text-rendering: optimizeLegibility;
-  -webkit-font-smoothing: antialiased;
-  -moz-osx-font-smoothing: grayscale;
+  --color-background: #f4f6fb;
+  --color-sidebar: #ffffff;
+  --color-card: #ffffff;
+  --color-surface: rgba(255, 255, 255, 0.7);
+  --color-border: rgba(15, 23, 42, 0.08);
+  --color-text-primary: #0f172a;
+  --color-text-secondary: #475569;
+  --color-accent: #6366f1;
+  --color-accent-strong: #4f46e5;
+  --color-error: #ef4444;
+  --shadow-large: 0 30px 60px rgba(15, 23, 42, 0.12);
+  --shadow-soft: 0 10px 30px rgba(15, 23, 42, 0.08);
+  --radius-large: 32px;
+  --radius-medium: 16px;
+  --radius-small: 12px;
+  --transition-base: 200ms ease;
 }
 
-a {
-  font-weight: 500;
-  color: #646cff;
-  text-decoration: inherit;
+[data-theme='dark'] {
+  color-scheme: dark;
+  --color-background: #0b1120;
+  --color-sidebar: #111c32;
+  --color-card: rgba(17, 34, 64, 0.9);
+  --color-surface: rgba(17, 34, 64, 0.6);
+  --color-border: rgba(148, 163, 184, 0.18);
+  --color-text-primary: #f8fafc;
+  --color-text-secondary: #cbd5f5;
+  --color-accent: #a855f7;
+  --color-accent-strong: #9333ea;
+  --shadow-large: 0 30px 80px rgba(15, 23, 42, 0.5);
+  --shadow-soft: 0 20px 50px rgba(8, 47, 73, 0.45);
 }
-a:hover {
-  color: #535bf2;
+
+*, *::before, *::after {
+  box-sizing: border-box;
 }
 
 body {
   margin: 0;
-  display: flex;
-  place-items: center;
-  min-width: 320px;
+  background: var(--color-background);
+  color: var(--color-text-primary);
   min-height: 100vh;
 }
 
-h1 {
-  font-size: 3.2em;
-  line-height: 1.1;
+a {
+  color: inherit;
+}
+
+img {
+  max-width: 100%;
+  display: block;
 }
 
 button {
-  border-radius: 8px;
-  border: 1px solid transparent;
-  padding: 0.6em 1.2em;
-  font-size: 1em;
-  font-weight: 500;
-  font-family: inherit;
-  background-color: #1a1a1a;
+  font: inherit;
   cursor: pointer;
-  transition: border-color 0.25s;
-}
-button:hover {
-  border-color: #646cff;
-}
-button:focus,
-button:focus-visible {
-  outline: 4px auto -webkit-focus-ring-color;
 }
 
-@media (prefers-color-scheme: light) {
-  :root {
-    color: #213547;
-    background-color: #ffffff;
-  }
-  a:hover {
-    color: #747bff;
-  }
-  button {
-    background-color: #f9f9f9;
-  }
+button:disabled {
+  cursor: not-allowed;
+  opacity: 0.7;
+}
+
+button,
+input {
+  border: none;
+  outline: none;
+  background: none;
+}
+
+input::placeholder {
+  color: inherit;
+  opacity: 0.6;
+}
+
+:focus-visible {
+  outline: 3px solid var(--color-accent);
+  outline-offset: 2px;
 }

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -2,9 +2,15 @@ import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
 import './index.css'
 import App from './App.jsx'
+import { SettingsProvider } from './context/SettingsContext.jsx'
+import { WeatherProvider } from './context/WeatherContext.jsx'
 
 createRoot(document.getElementById('root')).render(
   <StrictMode>
-    <App />
+    <SettingsProvider>
+      <WeatherProvider>
+        <App />
+      </WeatherProvider>
+    </SettingsProvider>
   </StrictMode>,
 )

--- a/src/services/weatherService.js
+++ b/src/services/weatherService.js
@@ -1,0 +1,215 @@
+const BASE_URL = 'https://api.openweathermap.org/data/2.5'
+const API_KEY = import.meta.env.VITE_OPENWEATHER_API_KEY
+
+function assertApiKey() {
+  if (!API_KEY) {
+    throw new Error('No se encontró la API Key de OpenWeather. Definí la variable VITE_OPENWEATHER_API_KEY en un archivo .env.local.')
+  }
+}
+
+function buildUrl(pathname, searchParams) {
+  const url = new URL(pathname, BASE_URL)
+  url.search = searchParams.toString()
+  return url.toString()
+}
+
+async function requestJson(pathname, params, { signal } = {}) {
+  const searchParams = new URLSearchParams(params)
+  searchParams.set('appid', API_KEY)
+
+  const response = await fetch(buildUrl(pathname, searchParams), { signal })
+
+  if (!response.ok) {
+    let message = 'No se pudo obtener la información del clima.'
+
+    try {
+      const errorPayload = await response.json()
+      if (errorPayload?.message) {
+        message = errorPayload.message
+      }
+    } catch {
+      // ignored
+    }
+
+    const error = new Error(message)
+    error.status = response.status
+    throw error
+  }
+
+  return response.json()
+}
+
+function degreesToCardinal(degrees) {
+  if (typeof degrees !== 'number' || Number.isNaN(degrees)) return null
+
+  const directions = ['N', 'NNE', 'NE', 'ENE', 'E', 'ESE', 'SE', 'SSE', 'S', 'SSO', 'SO', 'OSO', 'O', 'ONO', 'NO', 'NNO']
+  const index = Math.round(degrees / 22.5) % 16
+  return directions[index]
+}
+
+function getLocalDateKey(timestampSeconds, timezoneOffsetSeconds) {
+  const date = new Date((timestampSeconds + timezoneOffsetSeconds) * 1000)
+  const year = date.getUTCFullYear()
+  const month = `${date.getUTCMonth() + 1}`.padStart(2, '0')
+  const day = `${date.getUTCDate()}`.padStart(2, '0')
+  return `${year}-${month}-${day}`
+}
+
+function getLocalHour(timestampSeconds, timezoneOffsetSeconds) {
+  const date = new Date((timestampSeconds + timezoneOffsetSeconds) * 1000)
+  return date.getUTCHours()
+}
+
+function selectRepresentativeEntry(entries, timezoneOffsetSeconds) {
+  if (!entries || entries.length === 0) return null
+
+  const targetHour = 12
+  return entries.reduce((best, entry) => {
+    if (!best) return entry
+
+    const bestHour = getLocalHour(best.dt, timezoneOffsetSeconds)
+    const entryHour = getLocalHour(entry.dt, timezoneOffsetSeconds)
+
+    const bestDiff = Math.abs(bestHour - targetHour)
+    const entryDiff = Math.abs(entryHour - targetHour)
+
+    if (entryDiff < bestDiff) {
+      return entry
+    }
+
+    return best
+  }, null)
+}
+
+function buildDailyForecast(entries, timezoneOffsetSeconds) {
+  if (!Array.isArray(entries)) return []
+
+  const byDate = new Map()
+
+  entries.forEach((entry) => {
+    const key = getLocalDateKey(entry.dt, timezoneOffsetSeconds)
+    const bucket = byDate.get(key)
+    if (bucket) {
+      bucket.push(entry)
+    } else {
+      byDate.set(key, [entry])
+    }
+  })
+
+  const days = Array.from(byDate.entries())
+    .sort(([dayA], [dayB]) => (dayA < dayB ? -1 : dayA > dayB ? 1 : 0))
+    .map(([dateKey, dayEntries]) => {
+      let minTemp = Number.POSITIVE_INFINITY
+      let maxTemp = Number.NEGATIVE_INFINITY
+
+      dayEntries.forEach((entry) => {
+        const { main } = entry
+        if (!main) return
+        if (typeof main.temp_min === 'number') {
+          minTemp = Math.min(minTemp, main.temp_min)
+        }
+        if (typeof main.temp_max === 'number') {
+          maxTemp = Math.max(maxTemp, main.temp_max)
+        }
+      })
+
+      const representative = selectRepresentativeEntry(dayEntries, timezoneOffsetSeconds) ?? dayEntries[0]
+      const representativeWeather = representative?.weather?.[0] ?? {}
+
+      return {
+        dateKey,
+        timestamp: representative?.dt ?? dayEntries[0]?.dt,
+        minTemp: Number.isFinite(minTemp) ? minTemp : null,
+        maxTemp: Number.isFinite(maxTemp) ? maxTemp : null,
+        icon: representativeWeather.icon ?? '01d',
+        description: representativeWeather.description ?? '',
+      }
+    })
+
+  const todayKey = getLocalDateKey(Math.floor(Date.now() / 1000), timezoneOffsetSeconds)
+  const filteredDays = days.filter((day) => day.dateKey >= todayKey)
+
+  return filteredDays.slice(0, 5)
+}
+
+function normalizeCurrentWeather(payload) {
+  const weatherInfo = payload.weather?.[0] ?? {}
+  const timezoneOffset = payload.timezone ?? 0
+
+  return {
+    location: {
+      name: payload.name,
+      country: payload.sys?.country ?? '',
+      coordinates: {
+        lat: payload.coord?.lat ?? null,
+        lon: payload.coord?.lon ?? null,
+      },
+      timezoneOffset,
+    },
+    current: {
+      timestamp: payload.dt ?? null,
+      temperature: payload.main?.temp ?? null,
+      feelsLike: payload.main?.feels_like ?? null,
+      humidity: payload.main?.humidity ?? null,
+      pressure: payload.main?.pressure ?? null,
+      tempMin: payload.main?.temp_min ?? null,
+      tempMax: payload.main?.temp_max ?? null,
+      description: weatherInfo.description ?? '',
+      icon: weatherInfo.icon ?? '01d',
+      visibility: payload.visibility ?? null,
+      windSpeed: payload.wind?.speed ?? null,
+      windDeg: payload.wind?.deg ?? null,
+      windDirection: degreesToCardinal(payload.wind?.deg),
+      clouds: payload.clouds?.all ?? null,
+      sunrise: payload.sys?.sunrise ?? null,
+      sunset: payload.sys?.sunset ?? null,
+    },
+  }
+}
+
+export async function getWeatherData({ type, value, units = 'metric', signal } = {}) {
+  assertApiKey()
+
+  if (!type || !value) {
+    throw new Error('Se necesita una ciudad o coordenadas para buscar el clima.')
+  }
+
+  const params = { units }
+
+  if (type === 'city') {
+    params.q = value
+  } else if (type === 'coords' && typeof value === 'object') {
+    params.lat = value.lat
+    params.lon = value.lon
+  } else {
+    throw new Error('Tipo de búsqueda inválido.')
+  }
+
+  const currentPayload = await requestJson('/weather', params, { signal })
+  const { location, current } = normalizeCurrentWeather(currentPayload)
+
+  if (
+    location.coordinates.lat == null ||
+    Number.isNaN(location.coordinates.lat) ||
+    location.coordinates.lon == null ||
+    Number.isNaN(location.coordinates.lon)
+  ) {
+    throw new Error('No fue posible obtener las coordenadas de la ciudad seleccionada.')
+  }
+
+  const forecastPayload = await requestJson(
+    '/forecast',
+    { units, lat: location.coordinates.lat, lon: location.coordinates.lon },
+    { signal },
+  )
+
+  const forecast = buildDailyForecast(forecastPayload.list, location.timezoneOffset)
+
+  return {
+    location,
+    current,
+    forecast,
+    units,
+    updatedAt: Date.now(),
+  }
+}

--- a/src/utils/formatters.js
+++ b/src/utils/formatters.js
@@ -1,0 +1,108 @@
+const LOCALE = 'es-AR'
+export const DEFAULT_LOCALE = LOCALE
+
+const TEMPERATURE_SYMBOL = {
+  metric: '°C',
+  imperial: '°F',
+}
+
+const SPEED_UNIT = {
+  metric: 'km/h',
+  imperial: 'mph',
+}
+
+const DISTANCE_UNIT = {
+  metric: 'km',
+  imperial: 'mi',
+}
+
+export function formatTemperature(value, units = 'metric', { withUnit = true } = {}) {
+  if (typeof value !== 'number' || Number.isNaN(value)) return '--'
+  const rounded = Math.round(value)
+  return withUnit ? `${rounded}${TEMPERATURE_SYMBOL[units] ?? '°'}` : `${rounded}`
+}
+
+export function formatSpeed(value, units = 'metric') {
+  if (typeof value !== 'number' || Number.isNaN(value)) return '--'
+
+  const converted = units === 'metric' ? value * 3.6 : value
+  const unit = SPEED_UNIT[units] ?? 'km/h'
+
+  return `${Math.round(converted)} ${unit}`
+}
+
+export function formatDistance(meters, units = 'metric') {
+  if (typeof meters !== 'number' || Number.isNaN(meters)) return '--'
+
+  if (units === 'imperial') {
+    const miles = meters / 1609.34
+    return `${miles.toFixed(1)} ${DISTANCE_UNIT.imperial}`
+  }
+
+  const kilometers = meters / 1000
+  return `${kilometers.toFixed(1)} ${DISTANCE_UNIT.metric}`
+}
+
+export function formatPercentage(value) {
+  if (typeof value !== 'number' || Number.isNaN(value)) return '--'
+  return `${Math.round(value)}%`
+}
+
+export function formatPressure(value) {
+  if (typeof value !== 'number' || Number.isNaN(value)) return '--'
+  return `${Math.round(value)} hPa`
+}
+
+export function formatTime(timestampSeconds, timezoneOffsetSeconds, options) {
+  if (typeof timestampSeconds !== 'number') return '--'
+  const date = new Date((timestampSeconds + timezoneOffsetSeconds) * 1000)
+
+  try {
+    return new Intl.DateTimeFormat(LOCALE, {
+      hour: '2-digit',
+      minute: '2-digit',
+      timeZone: 'UTC',
+      ...options,
+    }).format(date)
+  } catch {
+    return date.toUTCString()
+  }
+}
+
+export function formatDate(timestampSeconds, timezoneOffsetSeconds, options) {
+  if (typeof timestampSeconds !== 'number') return '--'
+  const date = new Date((timestampSeconds + timezoneOffsetSeconds) * 1000)
+
+  const formatOptions = {
+    weekday: 'long',
+    day: 'numeric',
+    month: 'long',
+    timeZone: 'UTC',
+    ...options,
+  }
+
+  try {
+    return capitalize(
+      new Intl.DateTimeFormat(LOCALE, formatOptions).format(date),
+    )
+  } catch {
+    return date.toUTCString()
+  }
+}
+
+export function formatShortDate(timestampSeconds, timezoneOffsetSeconds) {
+  return formatDate(timestampSeconds, timezoneOffsetSeconds, {
+    weekday: 'short',
+    month: 'short',
+  })
+}
+
+export function capitalize(text) {
+  if (!text) return ''
+  return `${text.charAt(0).toUpperCase()}${text.slice(1)}`
+}
+
+export function getWeatherIconUrl(icon, size = 4) {
+  if (!icon) return null
+  return `https://openweathermap.org/img/wn/${icon}@${size}x.png`
+}


### PR DESCRIPTION
## Summary
- configure global Settings and Weather providers to persist theme/unit preferences and share the latest forecast
- build the weather UI with search, geolocation, forecast cards, highlights, and styling for light/dark themes
- add the OpenWeather service, data formatters, and project documentation for API key setup

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cc02a22a40832e9a07729d91fcb87e